### PR TITLE
Create README2.md

### DIFF
--- a/documentation/MeetingMinutes/README2.md
+++ b/documentation/MeetingMinutes/README2.md
@@ -1,0 +1,5 @@
+## Meeting Minutes of Call Forwarding Signal Sub Project
+
+Starting with the beginning of 2024 the meeting minutes of Quality on Demand calls are within the CAMARA Wiki at:
+
+https://wiki.camaraproject.org/display/CAM/SP-CFS+Minutes

--- a/documentation/MeetingMinutes/README2.md
+++ b/documentation/MeetingMinutes/README2.md
@@ -1,5 +1,5 @@
 ## Meeting Minutes of Call Forwarding Signal Sub Project
 
-Starting with the beginning of 2024 the meeting minutes of Quality on Demand calls are within the CAMARA Wiki at:
+Starting with the beginning of 2024 the meeting minutes of Call Forwarding Signal calls are within the CAMARA Wiki at:
 
 https://wiki.camaraproject.org/display/CAM/SP-CFS+Minutes


### PR DESCRIPTION
link to Confluence for the meeting minutes

#### What type of PR is this?

* documentation



#### What this PR does / why we need it:

To provide a link to the CFS Confluence wiki Page where the Meeting minutes are stored.


