### PR TITLE
Gherkin: 400.2_empty_request_body

### DIFF
--- a/code/Test_definitions/call-forwarding-signal-every-forwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-every-forwarding.feature
@@ -100,7 +100,7 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation call-forwardings
     And the response property "$.message" contains a user friendly text
 
   @call_forwarding_signal_400.2_empty_request_body
-  Scenario: Empty object as request body
+  Scenario: Empty object as request body with 2-legs authentication
     Given the request body is set to "{}"
     When the HTTP "POST" request is sent
     Then the response status code is 400
@@ -209,3 +209,4 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation call-forwardings
     And the response property "$.status" is 501
     And the response property "$.code" is "NOT_IMPLEMENTED"
     And the response property "$.message" contains a user friendly text
+  

--- a/code/Test_definitions/call-forwarding-signal-unconditional.feature
+++ b/code/Test_definitions/call-forwarding-signal-unconditional.feature
@@ -79,7 +79,7 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation unconditional-cal
     And the response property "$.message" contains a user friendly text
 
   @call_forwarding_signal_400.2_empty_request_body
-  Scenario: Empty object as request body
+  Scenario: Empty object as request body with 2-legs authentication
     Given the request body is set to "{}"
     When the HTTP "POST" request is sent
     Then the response status code is 400


### PR DESCRIPTION
#### What type of PR is this?
* correction
* documentation
* tests


#### What this PR does / why we need it:
test cases 400.2 are valid only with 2-legs. This PR fixes it.

#### Which issue(s) this PR fixes:
https://github.com/camaraproject/CallForwardingSignal/issues/137
