### PR TITLE
phoneNumber valorised with 3Legs

### DIFF
--- a/code/API_definitions/call-forwarding-signal.yaml
+++ b/code/API_definitions/call-forwarding-signal.yaml
@@ -318,7 +318,7 @@ components:
     CreateCallForwardingSignal:
       description: resource containing the phone number (PhoneNumber) regarding
        which the Call Forwarding Service must be checked. To be valorised only
-       in caso of two-legged authentication. If valorised with three-legged
+       in case of two-legged authentication. If valorised with three-legged
        authentication a 422-UNNECESSARY_IDENTIFIER error code is returned.
       type: object
       properties:

--- a/code/API_definitions/call-forwarding-signal.yaml
+++ b/code/API_definitions/call-forwarding-signal.yaml
@@ -48,9 +48,11 @@ info:
     \
     **phoneNumber**
     This is the end user phone number. The CFS API verifies if a call forwarding
-    service is active on this phone number. Note: the value of this optional
-    parameter and must be valorised only in case of two-legged authentication.
-    token.\
+    service is active on this phone number. Note: this parameter must be
+    must be valorised only in case of two-legged authentication. In case of
+    three-legged authentication the phone number is retrived by the access
+    token.
+    \
     \
     **CreateCallForwardingSignal**
     This is the resource the API Consumer uses to define the phone number to
@@ -59,7 +61,7 @@ info:
     **UnconditionalCallForwardingSignal**
     This is the resource the API Consumer gets back, containing the information
     about the Unconditional Call Forwarding Service status for the given phone
-    number (PhoneNumber)\
+    number (PhoneNumber).\
     \
     **CallForwardingSignal**
     This is the resource the API Consumer gets back, containing the information
@@ -316,7 +318,8 @@ components:
     CreateCallForwardingSignal:
       description: resource containing the phone number (PhoneNumber) regarding
        which the Call Forwarding Service must be checked. To be valorised only
-       in caso of two-legged authentication.
+       in caso of two-legged authentication. If valorised with three-legged
+       authentication a 422-UNNECESSARY_IDENTIFIER error code is returned.
       type: object
       properties:
         phoneNumber:
@@ -441,7 +444,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - INVALID_TOKEN_CONTEXT
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have
@@ -451,13 +453,6 @@ components:
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform
                   this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in
-                some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "phoneNumber is not consistent with access token."
     Generic404:
       description: Not found
       headers:

--- a/code/Test_definitions/call-forwarding-signal-every-forwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-every-forwarding.feature
@@ -119,7 +119,7 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation call-forwardings
     And the response property "$.message" contains a user friendly text
 
  # Generic 403 error - insufficient permission
- @call_forwarding_signal_403.1_permission_denied
+ @call_forwarding_signal_403_permission_denied
  Scenario: Endpoint invoked with an authentication token not valid for the endpoint context
     Given an access token with an invalid context
     When the HTTP "POST" request is sent
@@ -127,16 +127,6 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation call-forwardings
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
-
- @call_forwarding_signal_403.2_invalid_context
-  Scenario: Endpoint invoked with an access token invoking a different phone number from the phone number in the body
-      Given the request body property "$.phoneNumber" is set to a valid phone number
-      And The header "Authorization" is set to a valid access token identifying another phone number
-      When the HTTP "POST" request is sent
-      Then the response status code is 403
-      And the response property "$.status" is 403
-      And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-      And the response property "$.message" contains a user friendly text
  
  # Generic 404 error - unknown phone number
   @call_forwarding_signal_404.1_call_forwarding_for_unknown_phoneNumber

--- a/code/Test_definitions/call-forwarding-signal-unconditional.feature
+++ b/code/Test_definitions/call-forwarding-signal-unconditional.feature
@@ -98,7 +98,7 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation unconditional-cal
     And the response property "$.message" contains a user friendly text
 
   # Generic 403 error - insufficient permission
-  @call_forwarding_signal_403.1_permission_denied
+  @call_forwarding_signal_403_permission_denied
   Scenario: Endpoint invoked with an authentication token not valid for the endpoint context
     Given an access token with an invalid context
     When the HTTP "POST" request is sent
@@ -106,16 +106,6 @@ Feature: CAMARA Call Fowarwing Signal  API, v1.0.0 - Operation unconditional-cal
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
-
-  @call_forwarding_signal_403.2_invalid_context
-  Scenario: Endpoint invoked with phoneNumber retrieved from the access token different from phoneNumber in the body
-      Given the request body property "$.phoneNumber" is set to a valid phone number
-      And The header "Authorization" is set to a valid access token identifying a different valid phone number 
-      When the HTTP "POST" request is sent
-      Then the response status code is 403
-      And the response property "$.status" is 403
-      And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-      And the response property "$.message" contains a user friendly text
   
   # Generic 404 error - unknown phone number
   @call_forwarding_signal_404.1_unconditional_call_forwarding_for_unknown_phoneNumber


### PR DESCRIPTION
In case of phoneNumber valorized with 3Legs, 422-UNNECESSARY_IDENTIFIER is returned

#### What type of PR is this?
* correction
* cleanup
* documentation

#### What this PR does / why we need it:
Currently with 3Legs, if phoneNumber is valorized and different from the access token, the returned error is 403-INVALID_TOKEN_CONTEXT. This allows indirect number verification. This PR solves this issue returning 422-UNNECESSARY_IDENTIFIER. For YAML and Gherkin files.


#### Which issue(s) this PR fixes:
https://github.com/camaraproject/CallForwardingSignal/issues/141
https://github.com/camaraproject/CallForwardingSignal/issues/143
