### PR TITLE
fix: remove conflicting 400.2 test case from .feature files

### DIFF
--- a/code/Test_definitions/call-forwarding-signal-retrieveCallForwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-retrieveCallForwarding.feature
@@ -101,15 +101,6 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @call_forwarding_signal_400.2_empty_request_body
-  Scenario: Empty object as request body with 2-legs authentication
-    Given the request body is set to "{}"
-    When the HTTP "POST" request is sent
-    Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
-
   @call_forwarding_signal_400.3_C02.01_phone_number_not_schema_compliant
   Scenario: Phone number value does not comply with the schema (with 2-legs authentication)
     Given the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"

--- a/code/Test_definitions/call-forwarding-signal-retrieveUnconditionalCallForwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-retrieveUnconditionalCallForwarding.feature
@@ -80,15 +80,6 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveUnconditio
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @call_forwarding_signal_400.2_empty_request_body
-  Scenario: Empty object as request body with 2-legs authentication
-    Given the request body is set to "{}"
-    When the HTTP "POST" request is sent
-    Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
-
   @call_forwarding_signal_400.3_C02.01_phone_number_not_schema_compliant
   Scenario: Phone number value does not comply with the schema (with 2-legs authentication)
     Given the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"


### PR DESCRIPTION
#### What type of PR is this?
correction

#### What this PR does / why we need it:
Removes the `400.2_empty_request_body` test case from both `.feature` files. This test conflicts with `422.1_missing_phone_number` — both send `{}` as the request body with the same token context but expect different responses (400 vs 422).

Since `phoneNumber` is the only field in `CreateCallForwardingSignal` and it is optional, `{}` is a schema-valid body. The correct error for a missing phone number that cannot be derived from the access token is `422 MISSING_IDENTIFIER`, not `400 INVALID_ARGUMENT`.

#### Which issue(s) this PR fixes:
Fixes #218

#### Special notes for reviewers:
As suggested by @FabrizioMoggio in the [issue discussion](https://github.com/camaraproject/CallForwardingSignal/issues/218#issuecomment-2694040521).

#### Changelog input
```release-note
Removed conflicting 400.2_empty_request_body test case from both .feature files. The case is already covered by 422.1_missing_phone_number.
```

#### Additional documentation
N/A