### PR TITLE
Release Plan update for Sync26

### DIFF
--- a/.github/workflows/spectral-oas-caller.yml
+++ b/.github/workflows/spectral-oas-caller.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   spectral:
   # Invoke the reusable PR validation workflow from the main branch of camaraproject/tooling
-    uses: camaraproject/tooling/.github/workflows/spectral-oas.yml@v0
+    uses: rartych/tooling/.github/workflows/spectral-oas.yml@dev
 # Spectral configuration from the tooling repository subfolder of /linting/config/ indicated by `configurations` variable
 # If needed, you can specify a configuration from another subfolder of camaraproject/tooling/linting/config/ (uncomment below)
 #    with:

--- a/.github/workflows/spectral-oas-caller.yml
+++ b/.github/workflows/spectral-oas-caller.yml
@@ -35,8 +35,8 @@ permissions:
 jobs:
   spectral:
   # Invoke the reusable PR validation workflow from the main branch of camaraproject/tooling
-    uses: rartych/tooling/.github/workflows/spectral-oas.yml@dev
+    uses: rartych/tooling/.github/workflows/spectral-oas.yml@main
 # Spectral configuration from the tooling repository subfolder of /linting/config/ indicated by `configurations` variable
 # If needed, you can specify a configuration from another subfolder of camaraproject/tooling/linting/config/ (uncomment below)
-#    with:
-#      configurations: api-name
+    with:
+      configurations: dev

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,31 +10,31 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r3.3
+  target_release_tag: r4.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.3
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: call-forwarding-signal
-    target_api_version: 0.4.0
-    target_api_status: public
+    target_api_version: 0.5.0
+    target_api_status: rc
     main_contacts:
       - FabrizioMoggio
       - bigludo7


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:

The `release-plan.yaml` file requires updates to align with the **Sync26** meta-release cycle and prepare for the **r4.1** release. 
  - Set `meta_release: Sync26`.
  - Increment `target_release_tag` to `r4.1`.
  - Set `target_release_type` to `pre-release-rc`.
  - Update dependencies:
    - `commonalities_release: r4.3`.
    - `identity_consent_management_release: r4.2`.
  - Update the `call-forwarding-signal` API:
    - Version: `0.5.0`.
    - Status: `rc`.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 Plan update for release candidate r4.1

```

