### PR TITLE
fix: correct OAS schema refs and response body assertions in test definitions

### DIFF
--- a/code/Test_definitions/call-forwarding-signal-retrieveCallForwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-retrieveCallForwarding.feature
@@ -29,7 +29,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "/components/schemas/CallForwardingSignal"
+    And the response body complies with the OAS schema at "#/components/schemas/CallForwardingSignal"
 
   @call_forwarding_signal_01.1_generic_success_scenario_3-legs
   Scenario: Common validations for any success scenario with 3-legs authentication
@@ -41,7 +41,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "/components/schemas/CallForwardingSignal"
+    And the response body complies with the OAS schema at "#/components/schemas/CallForwardingSignal"
 
   #CFS inactive: phone number defined by phoneNumber (2-legs authentication) and the CFS status for the phone number is known by the network.
   @call_forwarding_signal_02_call_forwarding_check_not_active_phoneNumber
@@ -52,7 +52,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is a string with the value "inactive"
+    And the response body is an array of strings with the possible values ["inactive"]
 
   #CFS inactive: phone number obtained from the access token (3-legs authentication) and the CFS status for the phone number is known by the network. phoneNumber not set
   @call_forwarding_signal_03_call_forwarding_check_not_active_access_token
@@ -64,7 +64,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is a string with the value "inactive"
+    And the response body is an array of strings with the possible values ["inactive"]
 
   #CFS active: phone number defined by phoneNumber (2-legs authentication) and the CFS status for the phone number is known by the network.
   @call_forwarding_signal_04_call_forwarding_check_active_phoneNumber
@@ -103,7 +103,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveCallForwar
 
   @call_forwarding_signal_400.3_C02.01_phone_number_not_schema_compliant
   Scenario: Phone number value does not comply with the schema (with 2-legs authentication)
-    Given the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"
+    Given the request body property "$.phoneNumber" does not comply with the OAS schema at "#/components/schemas/PhoneNumber"
     When the HTTP "POST" request is sent
     Then the response status code is 400
     And the response property "$.status" is 400

--- a/code/Test_definitions/call-forwarding-signal-retrieveUnconditionalCallForwarding.feature
+++ b/code/Test_definitions/call-forwarding-signal-retrieveUnconditionalCallForwarding.feature
@@ -29,7 +29,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveUnconditio
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "/components/schemas/UnconditionalCallForwardingSignal"
+    And the response body complies with the OAS schema at "#/components/schemas/UnconditionalCallForwardingSignal"
 
   @call_forwarding_signal_01.1_generic_success_scenario_3-legs
   Scenario: Common validations for any success scenario with 3-legs authentication
@@ -42,7 +42,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveUnconditio
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "/components/schemas/UnconditionalCallForwardingSignal"
+    And the response body complies with the OAS schema at "#/components/schemas/UnconditionalCallForwardingSignal"
 
   # phone number defined by phoneNumber (2-legs authentication) and the CFS status for the phone number is known by the network.
   @call_forwarding_signal_02_unconditional_phoneNumber
@@ -53,7 +53,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveUnconditio
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/UnconditionalCallForwardingSignal"
+    And the response body complies with the OAS schema at "#/components/schemas/UnconditionalCallForwardingSignal"
     And the response body property "$.active" is one of: ["true", "false"]
 
   # phone number defined by access token and the CFS status for the phone number is known by the network. phoneNumber not set
@@ -82,7 +82,7 @@ Feature: CAMARA Call Forwarding Signal  API, vwip - Operation retrieveUnconditio
 
   @call_forwarding_signal_400.3_C02.01_phone_number_not_schema_compliant
   Scenario: Phone number value does not comply with the schema (with 2-legs authentication)
-    Given the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"
+    Given the request body property "$.phoneNumber" does not comply with the OAS schema at "#/components/schemas/PhoneNumber"
     When the HTTP "POST" request is sent
     Then the response status code is 400
     And the response property "$.status" is 400


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:

Fixes Gherkin test definitions:

- **Response body assertion**: fixed scenarios 02 and 03 in `retrieveCallForwarding.feature` where the response body was asserted as a plain string (`is a string with the value "inactive"`) — `CallForwardingSignal` is an array, so the correct assertion is `is an array of strings with the possible values ["inactive"]`
- **OAS schema refs**: replaced `/components/schemas/...` with `#/components/schemas/...` in all `complies with the OAS schema at` and `does not comply with the OAS schema at` steps in both feature files


#### Which issue(s) this PR fixes:

Fixes #228

#### Special notes for reviewers:

Scenarios 02 and 03 use the same step definition as scenarios 04/05: `the response body is an array of strings with the possible values [...]`, which simplifies test implementation.
The `#/components/schemas/...` form is the correct JSON Pointer / OAS local reference syntax used by the CAMARA test framework.

#### Changelog input

```
 Fixed OAS schema references and response body assertions in test definitions
```
